### PR TITLE
feat: enhance GitHub Pages workflow with manual trigger options

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -8,6 +8,20 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        required: false
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
+      force_rebuild:
+        description: 'Force a complete rebuild (ignore cache)'
+        required: false
+        default: false
+        type: boolean
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -26,6 +40,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Display manual trigger info
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "🚀 Manual deployment triggered"
+          echo "Environment: ${{ github.event.inputs.environment || 'production' }}"
+          echo "Force rebuild: ${{ github.event.inputs.force_rebuild || 'false' }}"
+
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
@@ -35,6 +56,9 @@ jobs:
         with:
           source: ./
           destination: ./_site
+        env:
+          JEKYLL_ENV: ${{ github.event.inputs.environment || 'production' }}
+          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
- Add workflow_dispatch trigger with configurable parameters
- Include environment selection (production/staging)
- Add force rebuild option for cache bypass
- Display trigger information in workflow logs
- Pass environment variables to Jekyll build process

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
